### PR TITLE
Fix Handling of Updating modifiers

### DIFF
--- a/Sources/iTextField/iTextField.swift
+++ b/Sources/iTextField/iTextField.swift
@@ -122,6 +122,41 @@ public struct iTextField: UIViewRepresentable {
     
     public func updateUIView(_ uiView: UITextField, context: Context) {
         uiView.text = text
+        textField.placeholder = placeholder
+        textField.font = font
+        textField.textColor = foregroundColor
+        if let textAlignment = textAlignment {
+            textField.textAlignment = textAlignment
+        }
+
+        textField.clearsOnBeginEditing = clearsOnBeginEditing
+        textField.clearsOnInsertion = clearsOnInsertion
+        
+        // Other settings
+        if let contentType = contentType {
+            textField.textContentType = contentType
+        }
+        if let accentColor = accentColor {
+            textField.tintColor = accentColor
+        }
+        textField.clearButtonMode = clearButtonMode
+        textField.autocorrectionType = autocorrection
+        textField.autocapitalizationType = autocapitalization
+        textField.keyboardType = keyboardType
+        textField.returnKeyType = returnKeyType
+        
+        textField.isSecureTextEntry = isSecure
+        textField.isUserInteractionEnabled = isUserInteractionEnabled
+        
+        textField.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        
+        textField.passwordRules = passwordRules
+        textField.smartDashesType = smartDashesType
+        textField.smartInsertDeleteType = smartInsertDeleteType
+        textField.smartQuotesType = smartQuotesType
+        textField.spellCheckingType = spellCheckingType
+
         if isEditing.wrappedValue {
             uiView.becomeFirstResponder()
         } else {

--- a/Sources/iTextField/iTextField.swift
+++ b/Sources/iTextField/iTextField.swift
@@ -120,8 +120,8 @@ public struct iTextField: UIViewRepresentable {
         return textField
     }
     
-    public func updateUIView(_ uiView: UITextField, context: Context) {
-        uiView.text = text
+    public func updateUIView(_ textField: UITextField, context: Context) {
+        textField.text = text
         textField.placeholder = placeholder
         textField.font = font
         textField.textColor = foregroundColor
@@ -158,9 +158,9 @@ public struct iTextField: UIViewRepresentable {
         textField.spellCheckingType = spellCheckingType
 
         if isEditing.wrappedValue {
-            uiView.becomeFirstResponder()
+            textField.becomeFirstResponder()
         } else {
-            uiView.resignFirstResponder()
+            textField.resignFirstResponder()
         }
     }
     


### PR DESCRIPTION
iTextValue currently does not react to changing values of modifiers.

This PR fixes that by setting all the properties of TextView again in the updateUIView method.

Works great in my testing.