### PR TITLE
Fix forced unwrap

### DIFF
--- a/Sources/iTextField/iTextField+ViewModifiers.swift
+++ b/Sources/iTextField/iTextField+ViewModifiers.swift
@@ -304,9 +304,11 @@ extension iTextField {
         
         var backgroundGray: Double { darkMode ? 0.25 : 0.95 }
         
-        var finalBGColor: Color = .init(white: backgroundGray);
-        if let backgroundColor = backgroundColor {
-            finalBGColor = backgroundColor
+        var finalBGColor: Color {
+            if let backgroundColor = backgroundColor {
+                return backgroundColor
+            }
+            return .init(white: backgroundGray);
         }
         
         var shadowOpacity: Double { (designEditing && hasShadow) ? 0.5 : 0 }

--- a/Sources/iTextField/iTextField+ViewModifiers.swift
+++ b/Sources/iTextField/iTextField+ViewModifiers.swift
@@ -287,15 +287,16 @@ extension iTextField {
     ///   - cornerRadius: Text field corner radius. Defaults to 6.
     ///   - hasShadow: Whether or not the text field has a shadow when selected. Defaults to true.
     /// - Returns: A stylized view containing a text field.
-    public func style(height: CGFloat = 58,
-               backgroundColor: Color? = nil,
-               accentColor: Color = Color(red: 0.30, green: 0.76, blue: 0.85),
-               font inputFont: UIFont? = nil,
-               paddingLeading: CGFloat = 25,
-               cornerRadius: CGFloat = 6,
-               hasShadow: Bool = true,
-               image: Image? = nil) -> some View
-    {
+    public func style(
+        height: CGFloat = 58,
+        backgroundColor: Color? = nil,
+        accentColor: Color = Color(red: 0.30, green: 0.76, blue: 0.85),
+        font inputFont: UIFont? = nil,
+        paddingLeading: CGFloat = 25,
+        cornerRadius: CGFloat = 6,
+        hasShadow: Bool = true,
+        image: Image? = nil
+    ) -> some View {
         var darkMode: Bool { colorScheme == .dark }
         
         let cursorColor: Color = accentColor

--- a/Sources/iTextField/iTextField+ViewModifiers.swift
+++ b/Sources/iTextField/iTextField+ViewModifiers.swift
@@ -303,12 +303,10 @@ extension iTextField {
         let leadingPadding: CGFloat = paddingLeading
         
         var backgroundGray: Double { darkMode ? 0.25 : 0.95 }
-        var backgroundColor: Color {
-            if backgroundColor != nil {
-                return backgroundColor!
-            } else {
-                return .init(white: backgroundGray)
-            }
+        
+        var finalBGColor: Color = .init(white: backgroundGray);
+        if let backgroundColor = backgroundColor {
+            finalBGColor = backgroundColor
         }
         
         var shadowOpacity: Double { (designEditing && hasShadow) ? 0.5 : 0 }
@@ -345,7 +343,7 @@ extension iTextField {
             .padding(.horizontal, leadingPadding)
         }
         .frame(height: height)
-        .background(backgroundColor)
+        .background(finalBGColor)
         .cornerRadius(cornerRadius)
         .overlay(RoundedRectangle(cornerRadius: cornerRadius).stroke(borderColor))
         .padding(.horizontal, leadingPadding)


### PR DESCRIPTION
This forced upward is causing a compile error in the newest release of xCode on my m1 mac. It might be related to M1 or just the newest version of Swift/XCode, but this fix should work either way.